### PR TITLE
Add ca-certs for clean wget over https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM gliderlabs/alpine:3.1
 
-RUN apk --update add tar wget
+RUN apk --update add tar wget ca-certificates
 
 ENV VERSION 1.13
 ENV APP HeavyThing-$VERSION
 
-RUN wget --no-check-certificate https://2ton.com.au/$APP.tar.gz
+RUN wget https://2ton.com.au/$APP.tar.gz
 RUN tar zxvf $APP.tar.gz
 WORKDIR $APP
 


### PR DESCRIPTION
Add ca-certificates so wget doesn't need to ignore 'unknown' certificates when downloading over SSL.
